### PR TITLE
feat: centralize table_registry usage for users and alembic

### DIFF
--- a/internum/core/models/__init__.py
+++ b/internum/core/models/__init__.py
@@ -1,0 +1,1 @@
+from internum.modules.users import models

--- a/internum/core/models/registry.py
+++ b/internum/core/models/registry.py
@@ -1,0 +1,3 @@
+from sqlalchemy.orm import registry
+
+table_registry = registry()

--- a/internum/modules/users/models.py
+++ b/internum/modules/users/models.py
@@ -2,11 +2,10 @@ from datetime import datetime
 
 from sqlalchemy import Boolean, func
 from sqlalchemy import Enum as SqlEnum
-from sqlalchemy.orm import Mapped, mapped_column, registry
+from sqlalchemy.orm import Mapped, mapped_column
 
+from internum.core.models.registry import table_registry
 from internum.modules.users.enums import Role, Setor
-
-table_registry = registry()
 
 
 @table_registry.mapped_as_dataclass

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -5,8 +5,8 @@ from sqlalchemy import pool
 
 from alembic import context
 
+from internum.core.models.registry import table_registry
 from internum.core.settings import Settings
-from internum.modules.users.models import table_registry
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,10 @@ quote-style = 'single'
 preview = true
 select = ['I', 'F', 'E', 'W', 'PL', 'PT', 'FAST']
 
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
+
+
 [tool.pytest.ini_options]
 pythonpath = "."
 addopts = '-p no:warnings'


### PR DESCRIPTION
- users.models agora utiliza table_registry centralizado (internum.core.models.registry)
- migrations/env.py importa o mesmo table_registry para o runtime do Alembic (evita import cycles e mantém mapeamento centralizado)
- pyproject.toml atualizado para adicionar ignore do ruff para __init__.py (F401)