### PR TITLE
chore: publish to GHCR and bump version to 1.0.0

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,64 @@
+name: Docker Publish
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/pedronora/internum-api
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+          labels: |
+            org.opencontainers.image.title=Internum API
+            org.opencontainers.image.description=Internum backend
+            org.opencontainers.image.vendor=Pedro Nora
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ github.ref_name }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -224,35 +224,34 @@ poetry run task format
 poetry run task test
 ```
 
-## 🐳 Deploy (Docker + TrueNAS)
+## 🐳 Deploy (Docker + GitHub Container Registry)
 
-1. Construir a imagem do backend localmente:
+Build local da imagem (tag `ghcr.io/pedronora/internum-api:local`):
 
 ```bash
 task dockerBuild
 ```
 
-Ou manualmente:
+A imagem de produção fica em **GHCR**: `ghcr.io/pedronora/internum-api`.
+
+- Tag de release: `:1.0.0` (imutável, usa-se em produção)
+- Tag de desenvolvimento: `:latest` e `:sha-<commit>`
+- O CI (`docker-publish.yaml`) publica `latest` nos merges para `main` e `X.Y.Z` quando uma tag `vX.Y.Z` é criada.
+
+No TrueNAS:
+
+1. Use a imagem `ghcr.io/pedronora/internum-api:1.0.0` (pull direto, sem `docker save/load`).
+2. Crie o app usando essa imagem.
+3. Configure as variáveis de ambiente de produção no painel (ex.: `POSTGRES_*`, `SECRET_KEY`, `MAILTRAP_TOKEN`) ou via `env_file`.
+
+## 🏷️ Criar uma release
 
 ```bash
-docker build -t internum-api:latest .
+git tag v1.0.0
+git push origin v1.0.0
 ```
 
-2. Exportar a imagem para arquivo:
-
-```bash
-docker save internum-api:latest -o internum-api-latest.tar
-```
-
-3. No TrueNAS, importar a imagem:
-
-```bash
-docker load -i internum-api-latest.tar
-```
-
-4. No TrueNAS, criar a aplicação/container usando a imagem importada (`internum-api:latest`).
-
-5. Configurar as variáveis de ambiente de produção no painel (ex.: `POSTGRES_*`, `DATABASE_URL`, `SECRET_KEY`, `MAILTRAP_TOKEN`).
+O CI publica a imagem com o rótulo da versão no GHCR.
 
 Observações:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "internum"
-version = "0.1.0"
+version = "1.0.0"
 description = ""
 authors = [{ name = "Pedro Nora", email = "pedro@nora.vc" }]
 readme = "README.md"
@@ -47,7 +47,7 @@ pre_test = 'task lint'
 test = 'pytest -s -x --cov=internum -vv'
 post_test = 'coverage html'
 commit = 'cz commit'
-dockerBuild = 'docker build -t internum-api:latest .'
+dockerBuild = 'docker build -t ghcr.io/pedronora/internum-api:local .'
 
 [tool.ruff]
 line-length = 79


### PR DESCRIPTION
Prepara o GitHub Container Registry:

- Versão do pyproject: `0.1.0` → `1.0.0`
- Novo workflow `docker-publish.yaml`: publica `latest`+sha em merges para `main` e `X.Y.Z` em tags `v*` (PR apenas build)
- README: instruções de pull do GHCR e criação de release