### PR TITLE
fix(vacation): ensure accrual periods for all active users in alerts

### DIFF
--- a/internum/core/scheduler/scheduler.py
+++ b/internum/core/scheduler/scheduler.py
@@ -5,6 +5,7 @@ from apscheduler.triggers.cron import CronTrigger
 
 from internum.modules.auth.jobs import delete_expired_reset_tokens
 from internum.modules.library.jobs import check_overdue_loans
+from internum.modules.vacation.jobs import ensure_accrual_periods_job
 
 scheduler = AsyncIOScheduler()
 
@@ -24,6 +25,13 @@ def start_scheduler():
         CronTrigger(hour=00, minute=00, timezone=timezone_sp),
         id='delete_expired_tokens',
         name='Deletar tokens expirados',
+    )
+
+    scheduler.add_job(
+        ensure_accrual_periods_job,
+        CronTrigger(hour=00, minute=00, timezone=timezone_sp),
+        id='ensure_accrual_periods',
+        name='Sincronizar períodos aquisitivos',
     )
 
     scheduler.start()

--- a/internum/modules/vacation/jobs.py
+++ b/internum/modules/vacation/jobs.py
@@ -1,0 +1,12 @@
+from internum.core.database import async_session_maker
+from internum.modules.vacation.services import CLTVacationService
+
+
+async def ensure_accrual_periods_job():
+    """Sincroniza períodos aquisitivos de todos os usuários ativos."""
+    print('[Scheduler] Sincronizando períodos aquisitivos...')
+    async with async_session_maker() as session:
+        service = CLTVacationService(session)
+        await service.ensure_all_users_accrual_periods()
+        await session.commit()
+    print('[Scheduler] Períodos aquisitivos sincronizados.')

--- a/internum/modules/vacation/services.py
+++ b/internum/modules/vacation/services.py
@@ -196,6 +196,14 @@ class CLTVacationService:  # noqa: PLR0904
         await self.session.flush()
         return periods
 
+    async def ensure_all_users_accrual_periods(self) -> None:
+        """Garante períodos aquisitivos de todos os usuários ativos."""
+        result = await self.session.execute(
+            select(User).where(User.active.is_(True))
+        )
+        for user in result.scalars().all():
+            await self.ensure_accrual_periods(user)
+
     async def get_accrual_periods(
         self, user: User
     ) -> list[VacationAccrualPeriod]:
@@ -776,6 +784,7 @@ class CLTVacationService:  # noqa: PLR0904
         - Em aberto sem férias marcadas ou solicitadas (basta marcar).
         """
         today = date.today()
+        await self.ensure_all_users_accrual_periods()
         result = await self.session.execute(
             select(VacationAccrualPeriod)
             .options(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "internum"
-version = "1.0.0"
+version = "1.0.1"
 description = ""
 authors = [{ name = "Pedro Nora", email = "pedro@nora.vc" }]
 readme = "README.md"

--- a/tests/test_vacation.py
+++ b/tests/test_vacation.py
@@ -1132,8 +1132,11 @@ def test_pending_alert_for_open_concessive_without_schedule(
     )
     assert response.status_code == HTTPStatus.OK
     alerts = response.json()
-    assert len(alerts) == 1
-    alert = alerts[0]
+    user_alerts = [
+        alert for alert in alerts if alert['user_id'] == vacation_user.id
+    ]
+    assert len(user_alerts) == 1
+    alert = user_alerts[0]
     assert alert['alert_type'] == 'pending'
     assert alert['remaining_days'] == VACATION_YEAR_DAYS
 
@@ -1150,8 +1153,33 @@ def test_about_to_expire_alert(client, about_to_expire_user, vacation_admin):
     )
     assert response.status_code == HTTPStatus.OK
     alerts = response.json()
-    assert len(alerts) == 1
-    assert alerts[0]['alert_type'] == 'about_to_expire'
+    user_alerts = [
+        alert
+        for alert in alerts
+        if alert['user_id'] == about_to_expire_user.id
+    ]
+    assert len(user_alerts) == 1
+    assert user_alerts[0]['alert_type'] == 'about_to_expire'
+
+
+@freeze_time(FROZEN_NOW)
+def test_alert_appears_for_user_without_prior_interaction(
+    client, vacation_old_user, vacation_admin
+):
+    """Usuário que nunca acessou o módulo deve aparecer nos alertas."""
+    response = client.get(
+        ENDPOINT_URL + '/alerts',
+        headers=auth_headers(client, vacation_admin),
+    )
+    assert response.status_code == HTTPStatus.OK
+    alerts = response.json()
+    user_alerts = [
+        alert for alert in alerts if alert['user_id'] == vacation_old_user.id
+    ]
+    assert user_alerts, (
+        'Usuário sem interação prévia deve aparecer nos alertas'
+    )
+    assert any(alert['alert_type'] == 'expired' for alert in user_alerts)
 
 
 @freeze_time(FROZEN_NOW)
@@ -1165,7 +1193,11 @@ def test_no_alert_when_request_pending(client, vacation_user, vacation_admin):
         headers=auth_headers(client, vacation_admin),
     )
     assert response.status_code == HTTPStatus.OK
-    assert response.json() == []
+    alerts = response.json()
+    user_alerts = [
+        alert for alert in alerts if alert['user_id'] == vacation_user.id
+    ]
+    assert user_alerts == []
 
 
 @freeze_time(FROZEN_NOW)
@@ -1186,7 +1218,11 @@ def test_no_alert_when_grant_active(client, vacation_user, vacation_admin):
         headers=auth_headers(client, vacation_admin),
     )
     assert response.status_code == HTTPStatus.OK
-    assert response.json() == []
+    alerts = response.json()
+    user_alerts = [
+        alert for alert in alerts if alert['user_id'] == vacation_user.id
+    ]
+    assert user_alerts == []
 
 
 # --- Filtro por setor/subsetor -------------------------------------------


### PR DESCRIPTION
## Problema

Coordenadores/funcionários que nunca acessaram o módulo de férias não apareciam nos Alertas de Férias, pois os períodos aquisitivos só eram criados de forma lazy, quando o próprio usuário abria seus endpoints.

## Correção

- `get_vacation_alerts()` agora garante os períodos aquisitivos de **todos os usuários ativos** antes de listar os alertas (`ensure_all_users_accrual_periods()`).
- Novo job diário (`vacation/jobs.py`, registrado no scheduler) para manter os períodos sincronizados.

## Testes

- 60 testes do módulo vacation passando (192 no total).
- Teste de regressão: usuário **sem** interação prévia aparece no alerta.
- Versão do pyproject: `1.0.1` (irá publicar a tag `v1.0.1` no GHCR).