### PR TITLE
feat(vacation): direct vacation registration and docker image optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog — internum-api
+
+Todas as mudanças relevantes desta imagem serão documentadas neste arquivo.
+
+O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/)
+e o versionamento segue o padrão [Semantic Versioning](https://semver.org/lang/pt-BR/).
+
+## [Unreleased]
+
+### Added
+
+- Cadastro direto de férias por Admin/Coord: `POST /accrual-periods/{user_id}/{period_id}/grants`
+  agora aceita `grant_type=normal` (gozo normal) em período concessivo, com as mesmas
+  validações CLT das solicitações (mín. 5 dias, sem início em sexta/sábado/domingo/feriado,
+  regra do saldo restante). A concessão nasce `GRANTED` (reserva dias) e segue para
+  confirmação de fruição pelo RH.
+
+### Changed
+
+- Otimização da imagem Docker: removida a duplicação de camada causada pelo
+  `chown -R` sobre o virtualenv. Os arquivos agora são copiados com
+  `COPY --chown=app:app`, mantendo apenas o `chmod` do entrypoint.
+  - Redução da imagem de ~316MB para ~210MB (~30% menor) sem alteração de runtime.
+
+## [1.0.1] - 2026-08-13
+
+### Changed
+
+- Refatoração do módulo de férias: substituição de `vacation_balances` e
+  `vacation_historical_periods` por `vacation_accrual_periods` (períodos
+  aquisitivos/concessivos) e `vacation_grants` (concessões), com status
+  `ACQUISITIVE → CONCESSIVE → EXPIRED/CLOSED`.
+- Renomeados os valores de enums do módulo de férias para refletir a semântica
+  de períodos aquisitivos e tipos de período (`MAIN`/`COMPLEMENTARY`).
+- Aprovação de solicitações de férias agora gera concessões e reserva de dias;
+  grants retroativo/dobro do admin nascem terminais (`FRUITED`/`PAID_DOUBLE`).
+- Consultas por setor (`GET /grants/by-sector/{setor}` e
+  `GET /requests/by-sector/{setor}`) para Admin/Coord com filtro opcional por
+  subsecretaria (`?subsetor=`).
+
+### Added
+
+- Endpoints de reset de senha (`/forgot-password`, `/reset-password`) com token
+  de propósito `password_reset` e e-mail via Mailtrap.
+- Suporte a feriados brasileiros (estado do PR) nas validações de férias.

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,14 +32,13 @@ RUN groupadd -r app && useradd -r -g app app
 
 WORKDIR /app
 
-COPY --from=builder /app/.venv /app/.venv
-COPY --from=builder /app/internum /app/internum
-COPY --from=builder /app/migrations /app/migrations
-COPY --from=builder /app/alembic.ini /app/alembic.ini
-COPY --from=builder /app/pyproject.toml /app/pyproject.toml
+COPY --chown=app:app --from=builder /app/.venv /app/.venv
+COPY --chown=app:app --from=builder /app/internum /app/internum
+COPY --chown=app:app --from=builder /app/migrations /app/migrations
+COPY --chown=app:app --from=builder /app/alembic.ini /app/alembic.ini
+COPY --chown=app:app --from=builder /app/pyproject.toml /app/pyproject.toml
 
-RUN chmod +x /app/internum/infra/entrypoint.sh \
-    && chown -R app:app /app
+RUN chmod +x /app/internum/infra/entrypoint.sh
 
 USER app
 

--- a/internum/modules/vacation/README.md
+++ b/internum/modules/vacation/README.md
@@ -146,7 +146,7 @@ Prefixo: `/api/v1/vacation` (definido em `internum/api/main.py`).
 | GET | `/accrual-periods/{user_id}` | Admin/Coord | Períodos de outro usuário |
 | GET | `/accrual-periods/{user_id}/{period_id}` | Admin/Coord | Período específico com concessões |
 | POST | `/accrual-periods/{user_id}/{period_id}/sell` | **Admin** | Vender dias (abono pecuniário) |
-| POST | `/accrual-periods/{user_id}/{period_id}/grants` | **Admin** | Cadastrar gozo retroativo ou pagamento em dobro |
+| POST | `/accrual-periods/{user_id}/{period_id}/grants` | Admin/Coord | Cadastrar concessão: `normal` (marcar férias em período concessivo), `retroactive`/`double_payment` (período expirado) |
 
 ### Solicitações (Requests)
 | Método | Rota | Permissão | Descrição |
@@ -207,15 +207,23 @@ Grants cadastrados pelo **admin** em período expirado (retroativo/dobro) são *
 já nascem `FRUITED`/`PAID_DOUBLE`, somam direto em `days_enjoyed`/`days_double_paid` e não passam
 pela confirmação do RH (nem reservam dias).
 
-### Fluxos especiais (apenas Admin)
+A **marcação direta** de férias (`grant_type=normal`) em período concessivo nasce `GRANTED`,
+reserva dias (`days_reserved`) e segue o fluxo normal de confirmação do RH
+(`POST /grants/{grant_id}/confirm-fruition`).
 
-1. **Venda de dias** (`POST .../sell`): abono pecuniário (Art. 143), máx. 10 dias/período,
+### Fluxos especiais (Admin/Coord)
+
+1. **Marcação direta de férias** (`grant_type=normal`): admin/coord registra o gozo em período
+   `CONCESSIVE` sem solicitação prévia. Valida as mesmas regras CLT das solicitações
+   (mín. 5 dias, sem início em sexta/sábado/domingo/feriado e regra do saldo restante).
+   Nasce `GRANTED` e reserva dias até a confirmação do RH.
+2. **Venda de dias** (`POST .../sell`): abono pecuniário (Art. 143), máx. 10 dias/período,
    apenas em período não expirado, respeitando saldo e a regra de gozo fracionado.
-2. **Gozo retroativo** (`grant_type=retroactive`): cadastro de gozo ocorrido no passado,
+3. **Gozo retroativo** (`grant_type=retroactive`): cadastro de gozo ocorrido no passado,
    apenas em período `EXPIRED`, mínimo 5 dias. Já nasce `FRUITED` e soma em `days_enjoyed`.
-3. **Pagamento em dobro** (`grant_type=double_payment`): indenização por não gozo (Art. 137),
+4. **Pagamento em dobro** (`grant_type=double_payment`): indenização por não gozo (Art. 137),
    apenas em período `EXPIRED`. Já nasce `PAID_DOUBLE` e soma em `days_double_paid`.
-4. **Alertas** (`GET /alerts`): lista períodos expirados com saldo a regularizar.
+5. **Alertas** (`GET /alerts`): lista períodos expirados com saldo a regularizar.
 
 ## Validações no Schema
 
@@ -232,10 +240,10 @@ VacationRequestCreate:
 VacationSellDaysRequest:
     days: int  # ge=1, le=10
 
-VacationGrantAdminCreate:  # Apenas Admin
+VacationGrantAdminCreate:  # Admin/Coord
     start_date: date
     end_date: date
-    grant_type: VacationGrantType  # retroactive | double_payment
+    grant_type: VacationGrantType  # normal | retroactive | double_payment
     notes: Optional[str]
 
 VacationConfirmFruitionRequest:
@@ -253,7 +261,7 @@ Métodos principais:
 - `approve_request(request, reviewer, notes)` - Aprova, cria grants e reserva dias
 - `reject_request(request, reviewer, notes)` - Rejeita
 - `cancel_request(request, user)` - Cancela (apenas dono, se pendente)
-- `create_grant(data, creator)` - Gozo retroativo/dobro (admin, período expirado); terminais (`FRUITED`/`PAID_DOUBLE`)
+- `create_grant(data, creator)` - Marcação direta (normal, período concessivo, com validação CLT) ou regularização (retroativo/dobro, período expirado)
 - `list_grants(user_id, status, accrual_period_id, setor, subsetor)` - Concessões com filtros (inclui por setor/subsetor do empregado)
 - `confirm_fruition(grant, user, confirm, notes)` - RH confirma/nega fruição
 - `sell_days(accrual, days, admin)` - Venda de dias (abono pecuniário)
@@ -268,8 +276,8 @@ VerifyAdminCoord     # role in ['admin', 'coord']
 VerifyAdmin          # role == 'admin'
 ```
 
-- **Admin/Coord** aprovam/rejeitam solicitações, veem dados de qualquer usuário e recebem alertas.
-- **Admin** (apenas) vende dias, cadastra gozo retroativo/dobro (terminais) e confirma fruição de grants normais.
+- **Admin/Coord** aprovam/rejeitam solicitações, veem dados de qualquer usuário, recebem alertas e cadastram concessões (`normal`/`retroactive`/`double_payment`).
+- **Admin** (apenas) vende dias e confirma fruição de grants normais.
 - **Usuário** consulta e solicita apenas seus próprios dados.
 
 ## Integração
@@ -297,7 +305,7 @@ poetry run alembic upgrade head
 
 ## Testes
 
-Todos os testes do módulo passam (58 casos em `tests/test_vacation.py`). Para executar:
+Todos os testes do módulo passam (64 casos em `tests/test_vacation.py`). Para executar:
 ```bash
 poetry run task test -- -k vacation
 ```

--- a/internum/modules/vacation/routers.py
+++ b/internum/modules/vacation/routers.py
@@ -181,7 +181,11 @@ async def create_vacation_grant(  # noqa: PLR0913, PLR0917
     current_user: VerifyAdminCoord,
     service: Annotated[CLTVacationService, Depends(get_vacation_service)],
 ):
-    """Cadastra gozo retroativo ou pagamento em dobro (admin/coord)."""
+    """Cadastra concessão de férias (admin/coord).
+
+    - normal: marcação direta de férias em período concessivo;
+    - retroactive / double_payment: regularização de período expirado.
+    """
     data = VacationGrantCreate(
         user_id=user_id,
         accrual_period_id=period_id,

--- a/internum/modules/vacation/services.py
+++ b/internum/modules/vacation/services.py
@@ -584,13 +584,21 @@ class CLTVacationService:  # noqa: PLR0904
     async def create_grant(
         self, data: VacationGrantCreate, creator: User
     ) -> VacationGrant:
-        """Admin cadastra gozo retroativo ou pagamento em dobro (Art. 137)."""
+        """Admin/coord cadastra concessão de férias.
+
+        - NORMAL: marca férias diretamente em período concessivo (grant
+          GRANTED, reserva dias; RH confirma a fruição depois);
+        - RETROACTIVE / DOUBLE_PAYMENT: regulariza período expirado
+          (Art. 137), grants terminais.
+        """
         if data.grant_type not in {
+            VacationGrantType.NORMAL,
             VacationGrantType.RETROACTIVE,
             VacationGrantType.DOUBLE_PAYMENT,
         }:
             raise ValueError(
-                'Tipo de concessão inválido; use retroactive ou double_payment'
+                'Tipo de concessão inválido; use normal, retroactive ou '
+                'double_payment'
             )
 
         result = await self.session.execute(
@@ -604,31 +612,15 @@ class CLTVacationService:  # noqa: PLR0904
             raise ValueError('Período aquisitivo não encontrado')
 
         self._sync_period(accrual, date.today())
-        if accrual.status != VacationAccrualStatus.EXPIRED:
-            raise ValueError(
-                'Apenas períodos com concessivo expirado aceitam '
-                'gozo retroativo ou pagamento em dobro'
-            )
-
-        days = self.count_calendar_days(data.start_date, data.end_date)
-        if days < 1:
-            raise ValueError('Período inválido')
-        if data.grant_type == VacationGrantType.RETROACTIVE:
-            if days < self.MIN_PERIOD_DAYS:
-                raise ValueError(
-                    f'Mínimo de {self.MIN_PERIOD_DAYS} dias corridos para gozo'
-                )
-        if days > accrual.available_days:
-            raise ValueError(
-                f'Dias ({days}) excedem saldo disponível '
-                f'({accrual.available_days})'
-            )
+        is_regularization = data.grant_type in {
+            VacationGrantType.RETROACTIVE,
+            VacationGrantType.DOUBLE_PAYMENT,
+        }
+        days = await self._validate_grant_dates(
+            data, accrual, creator, is_regularization
+        )
 
         now = datetime.now()
-        if data.grant_type == VacationGrantType.DOUBLE_PAYMENT:
-            status = VacationGrantStatus.PAID_DOUBLE
-        else:
-            status = VacationGrantStatus.FRUITED
         grant = VacationGrant(
             user_id=data.user_id,
             accrual_period_id=accrual.id,
@@ -636,22 +628,80 @@ class CLTVacationService:  # noqa: PLR0904
             end_date=data.end_date,
             days_count=days,
             grant_type=data.grant_type,
-            status=status,
+            status=self._grant_initial_status(data.grant_type),
             approved_by_id=creator.id,
             approved_at=now,
-            confirmed_by_id=creator.id,
-            confirmed_at=now,
+            confirmed_by_id=creator.id if is_regularization else None,
+            confirmed_at=now if is_regularization else None,
             notes=data.notes,
         )
         grant.created_by_id = creator.id
         self.session.add(grant)
         if data.grant_type == VacationGrantType.DOUBLE_PAYMENT:
             accrual.days_double_paid += days
+        elif data.grant_type == VacationGrantType.NORMAL:
+            accrual.days_reserved += days
         else:
             accrual.days_enjoyed += days
         self._sync_period(accrual, date.today())
         await self.session.flush()
         return grant
+
+    async def _validate_grant_dates(
+        self,
+        data: VacationGrantCreate,
+        accrual: VacationAccrualPeriod,
+        creator: User,
+        is_regularization: bool,
+    ) -> int:
+        """Valida datas/saldo de uma concessão cadastrada pelo admin."""
+        days = self.count_calendar_days(data.start_date, data.end_date)
+        if days < 1:
+            raise ValueError('Período inválido')
+
+        if is_regularization:
+            if accrual.status != VacationAccrualStatus.EXPIRED:
+                raise ValueError(
+                    'Apenas períodos com concessivo expirado aceitam '
+                    'gozo retroativo ou pagamento em dobro'
+                )
+            if days > accrual.available_days:
+                raise ValueError(
+                    f'Dias ({days}) excedem saldo disponível '
+                    f'({accrual.available_days})'
+                )
+            if (
+                data.grant_type == VacationGrantType.RETROACTIVE
+                and days < self.MIN_PERIOD_DAYS
+            ):
+                raise ValueError(
+                    f'Mínimo de {self.MIN_PERIOD_DAYS} dias corridos '
+                    'para gozo'
+                )
+            return days
+
+        if accrual.status != VacationAccrualStatus.CONCESSIVE:
+            raise ValueError(
+                'Apenas períodos em gozo (concessivo) aceitam '
+                'marcação direta de férias'
+            )
+        period = VacationPeriodCreate(
+            start_date=data.start_date, end_date=data.end_date
+        )
+        errors = await self.validate_periods_clt(creator, accrual, [period])
+        if errors:
+            raise ValueError('; '.join(errors))
+        return days
+
+    @staticmethod
+    def _grant_initial_status(
+        grant_type: VacationGrantType,
+    ) -> VacationGrantStatus:
+        if grant_type == VacationGrantType.DOUBLE_PAYMENT:
+            return VacationGrantStatus.PAID_DOUBLE
+        if grant_type == VacationGrantType.NORMAL:
+            return VacationGrantStatus.GRANTED
+        return VacationGrantStatus.FRUITED
 
     async def get_grant(self, grant_id: int) -> VacationGrant | None:
         result = await self.session.execute(

--- a/tests/test_vacation.py
+++ b/tests/test_vacation.py
@@ -936,6 +936,111 @@ def test_create_grant_on_non_expired_period(
 
 
 @freeze_time(FROZEN_NOW)
+def test_create_normal_grant_on_concessive_period(
+    client, vacation_user, vacation_admin
+):
+    headers = auth_headers(client, vacation_user)
+    period = get_period_by_status(client, headers, 'concessive')
+    response = client.post(
+        f'{ENDPOINT_URL}/accrual-periods/'
+        f'{vacation_user.id}/{period["id"]}/grants',
+        headers=auth_headers(client, vacation_admin),
+        json={
+            'start_date': MAIN_PERIOD['start_date'],
+            'end_date': MAIN_PERIOD['end_date'],
+            'grant_type': 'normal',
+            'notes': 'Marcado direto pelo RH',
+        },
+    )
+    assert response.status_code == HTTPStatus.CREATED
+    data = response.json()
+    assert data['grant_type'] == 'normal'
+    assert data['status'] == 'granted'
+    assert data['days_count'] == MAIN_CAL_DAYS
+    assert data['is_regularization'] is False
+    assert data['approved_by_id'] == vacation_admin.id
+    assert data['confirmed_by_id'] is None
+
+    updated = get_accrual_periods(client, headers)
+    period = next(p for p in updated if p['id'] == period['id'])
+    assert period['days_reserved'] == MAIN_CAL_DAYS
+    assert period['days_enjoyed'] == 0
+
+
+@freeze_time(FROZEN_NOW)
+def test_create_normal_grant_requires_concessive_period(
+    client, vacation_old_user, vacation_admin
+):
+    headers = auth_headers(client, vacation_old_user)
+    period = get_period_by_status(client, headers, 'expired')
+    response = client.post(
+        f'{ENDPOINT_URL}/accrual-periods/'
+        f'{vacation_old_user.id}/{period["id"]}/grants',
+        headers=auth_headers(client, vacation_admin),
+        json={
+            'start_date': '2025-06-12',
+            'end_date': '2025-06-21',
+            'grant_type': 'normal',
+        },
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert 'concessivo' in response.json()['detail']
+
+
+@freeze_time(FROZEN_NOW)
+def test_create_normal_grant_clt_validation(
+    client, vacation_user, vacation_admin
+):
+    headers = auth_headers(client, vacation_user)
+    period = get_period_by_status(client, headers, 'concessive')
+    response = client.post(
+        f'{ENDPOINT_URL}/accrual-periods/'
+        f'{vacation_user.id}/{period["id"]}/grants',
+        headers=auth_headers(client, vacation_admin),
+        json={
+            'start_date': WEEKEND_START_PERIOD['start_date'],
+            'end_date': WEEKEND_START_PERIOD['end_date'],
+            'grant_type': 'normal',
+        },
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert 'sábado' in response.json()['detail']
+
+
+@freeze_time(FROZEN_NOW)
+def test_create_normal_grant_can_confirm_fruition(
+    client, vacation_user, vacation_admin
+):
+    headers = auth_headers(client, vacation_user)
+    period = get_period_by_status(client, headers, 'concessive')
+    response = client.post(
+        f'{ENDPOINT_URL}/accrual-periods/'
+        f'{vacation_user.id}/{period["id"]}/grants',
+        headers=auth_headers(client, vacation_admin),
+        json={
+            'start_date': MAIN_PERIOD['start_date'],
+            'end_date': MAIN_PERIOD['end_date'],
+            'grant_type': 'normal',
+        },
+    )
+    assert response.status_code == HTTPStatus.CREATED
+    grant = response.json()
+
+    response = client.post(
+        f'{ENDPOINT_URL}/grants/{grant["id"]}/confirm-fruition',
+        headers=auth_headers(client, vacation_admin),
+        json={'confirm': True},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assert response.json()['status'] == 'fruited'
+
+    updated = get_accrual_periods(client, headers)
+    period = next(p for p in updated if p['id'] == period['id'])
+    assert period['days_reserved'] == 0
+    assert period['days_enjoyed'] == MAIN_CAL_DAYS
+
+
+@freeze_time(FROZEN_NOW)
 def test_double_payment_flow(client, vacation_old_user, vacation_admin):
     headers = auth_headers(client, vacation_old_user)
     period = get_period_by_status(client, headers, 'expired')


### PR DESCRIPTION
## Resumo
- **feat(vacation)**: Admin/Coord pode cadastrar gozo normal diretamente (`grant_type=normal`) em período concessivo, com validações CLT, nascendo como `GRANTED` (reserva dias) e seguindo para confirmação do RH.
- **perf(docker)**: imagem reduzida de ~316MB para ~210MB removendo a duplicação de camada do `chown -R` (troca por `COPY --chown`).
- Testes e documentação atualizados (README do módulo + CHANGELOG).

## Commits
- feat(vacation): allow admin/coord to register vacation directly (normal grant)
- test(vacation): cover direct normal grant registration
- perf(docker): reduce image size by removing duplicated layer
- docs(vacation): document direct grant registration
- docs(changelog): document recent api changes