### PR TITLE
chore: publish to GHCR and bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Todas as mudanças relevantes desta imagem serão documentadas neste arquivo.
 O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/)
 e o versionamento segue o padrão [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
-## [Unreleased]
+## [1.1.0] - 2026-08-13
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "internum"
-version = "1.0.1"
+version = "1.1.0"
 description = ""
 authors = [{ name = "Pedro Nora", email = "pedro@nora.vc" }]
 readme = "README.md"


### PR DESCRIPTION
Release 1.1.0 do internum-api: nova feature de marcação direta de férias + otimização de imagem Docker. Bump de `pyproject.toml` para 1.1.0 e CHANGELOG atualizado.