### PR TITLE
feat(security): sanitizar conteúdo rico com bleach

### DIFF
--- a/internum/modules/legal_briefs/schemas.py
+++ b/internum/modules/legal_briefs/schemas.py
@@ -4,6 +4,8 @@ from typing import Optional
 from fastapi import Query
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from internum.utils.sanitize import sanitize_rich_text
+
 
 class UserPublic(BaseModel):
     id: int
@@ -16,22 +18,30 @@ class LegalBriefCreate(BaseModel):
     title: str = Field(..., min_length=1)
     content: str = Field(..., min_length=1)
 
-    @field_validator('title', 'content', mode='before')
-    def strip_whitespace(cls, v):
+    @field_validator('title', mode='before')
+    def strip_title(cls, v):
         if isinstance(v, str):
             return v.strip()
         return v  # pragma: no cover
+
+    @field_validator('content', mode='before')
+    def sanitize_content(cls, v):
+        return sanitize_rich_text(v)
 
 
 class LegalBriefUpdate(BaseModel):
     title: str = Field(..., min_length=1)
     content: str = Field(..., min_length=1)
 
-    @field_validator('title', 'content', mode='before')
-    def strip_whitespace(cls, v):
+    @field_validator('title', mode='before')
+    def strip_title(cls, v):
         if isinstance(v, str):
             return v.strip()
         return v  # pragma: no cover
+
+    @field_validator('content', mode='before')
+    def sanitize_content(cls, v):
+        return sanitize_rich_text(v)
 
 
 class LegalBriefRevisionSchema(BaseModel):

--- a/internum/modules/notices/schemas.py
+++ b/internum/modules/notices/schemas.py
@@ -4,6 +4,8 @@ from typing import Optional
 from fastapi import Query
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from internum.utils.sanitize import sanitize_rich_text
+
 
 class UserPublic(BaseModel):
     id: int
@@ -14,11 +16,15 @@ class NoticeCreate(BaseModel):
     title: str = Field(..., min_length=1)
     content: str = Field(..., min_length=1)
 
-    @field_validator('title', 'content', mode='before')
-    def strip_whitespace(cls, v):
+    @field_validator('title', mode='before')
+    def strip_title(cls, v):
         if isinstance(v, str):
             return v.strip()
-        return v
+        return v  # pragma: no cover
+
+    @field_validator('content', mode='before')
+    def sanitize_content(cls, v):
+        return sanitize_rich_text(v)
 
 
 class NoticeReadSchema(BaseModel):

--- a/internum/utils/sanitize.py
+++ b/internum/utils/sanitize.py
@@ -1,0 +1,59 @@
+import bleach
+from bleach.css_sanitizer import CSSSanitizer
+
+# Tags/atributos aceitos para conteúdo rico gerado pelo editor TipTap.
+RICH_TEXT_TAGS = [
+    'p',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'strong',
+    'b',
+    'em',
+    'i',
+    'u',
+    's',
+    'strike',
+    'code',
+    'pre',
+    'ul',
+    'ol',
+    'li',
+    'blockquote',
+    'br',
+    'hr',
+    'a',
+    'span',
+]
+
+RICH_TEXT_ATTRIBUTES = {
+    'a': ['href', 'title', 'target', 'rel'],
+    'p': ['style'],
+    'h1': ['style'],
+    'h2': ['style'],
+    'h3': ['style'],
+    'h4': ['style'],
+    'h5': ['style'],
+    'h6': ['style'],
+    'li': ['style'],
+    'blockquote': ['style'],
+    'span': ['style'],
+}
+
+RICH_TEXT_CSS = CSSSanitizer(allowed_css_properties=['text-align'])
+
+
+def sanitize_rich_text(value: str) -> str:
+    """Sanitiza conteúdo HTML rico, mantendo tags do editor TipTap."""
+    if not isinstance(value, str):
+        return value
+    return bleach.clean(
+        value,
+        tags=RICH_TEXT_TAGS,
+        attributes=RICH_TEXT_ATTRIBUTES,
+        css_sanitizer=RICH_TEXT_CSS,
+        strip=True,
+    ).strip()

--- a/poetry.lock
+++ b/poetry.lock
@@ -169,6 +169,24 @@ cffi = [
 ]
 
 [[package]]
+name = "bleach"
+version = "6.4.0"
+description = "An easy safelist-based HTML-sanitizing tool."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "bleach-6.4.0-py3-none-any.whl", hash = "sha256:4b6b6a54fff2e69a3dde9d21cc6301220bee3c3cb792187d11403fd795031081"},
+    {file = "bleach-6.4.0.tar.gz", hash = "sha256:4202482733d85cedd04e59fcb2f89f4e4c7c385a78d3c3c23c30446843a37452"},
+]
+
+[package.dependencies]
+webencodings = "*"
+
+[package.extras]
+css = ["tinycss2 (>=1.1.0)"]
+
+[[package]]
 name = "certifi"
 version = "2026.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -2562,6 +2580,25 @@ trino = ["trino"]
 weaviate = ["weaviate-client (>=4)"]
 
 [[package]]
+name = "tinycss2"
+version = "1.5.1"
+description = "A tiny CSS parser"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661"},
+    {file = "tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957"},
+]
+
+[package.dependencies]
+webencodings = ">=0.4"
+
+[package.extras]
+doc = ["furo", "sphinx"]
+test = ["pytest", "ruff"]
+
+[[package]]
 name = "tomli"
 version = "2.4.1"
 description = "A lil' TOML parser"
@@ -2948,6 +2985,22 @@ files = [
 ]
 
 [[package]]
+name = "webencodings"
+version = "0.6.1"
+description = "Character encoding aliases for legacy web content"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "webencodings-0.6.1-py3-none-any.whl", hash = "sha256:7fab6269c8bf237c657876b52058ccb182e861518d1c695c1a9aaa8c1c105d5b"},
+    {file = "webencodings-0.6.1.tar.gz", hash = "sha256:565f9ad031c702dae404e27a099e3e09186a3ab1b9520f06d215502b651fd910"},
+]
+
+[package.extras]
+doc = ["furo", "sphinx"]
+test = ["pytest", "ruff"]
+
+[[package]]
 name = "websockets"
 version = "17.0.1"
 description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
@@ -3171,4 +3224,4 @@ dev = ["pytest", "setuptools"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13, <4.0"
-content-hash = "b413ddd5f0a3475ddff306a6223f002c89201710961da387cbb2d65d3c4be381"
+content-hash = "74aba3830ef7ec01e8ed249c737eca688a89737edd6e97567e598bc5b078398a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "apscheduler (>=3.11.1,<4.0.0)",
     "mailtrap (>=2.3.0,<3.0.0)",
     "holidays (>=0.52.0,<1.0.0)",
+    "bleach (>=6.4.0,<7.0.0)",
+    "tinycss2 (>=1.5.1,<2.0.0)",
 ]
 
 

--- a/tests/test_legal_brief.py
+++ b/tests/test_legal_brief.py
@@ -49,6 +49,57 @@ def test_create_legal_brief_without_permission(client, user, token):
     assert response.status_code == HTTPStatus.FORBIDDEN
 
 
+def test_create_legal_brief_sanitizes_content(
+    client, user_admin, token_admin
+):
+    new_legal_brief = {
+        'title': 'Ementa com HTML',
+        'content': (
+            '<p><strong>Texto</strong></p>'
+            '<script>alert("xss")</script>'
+            '<img src="x" onerror="alert(1)">'
+        ),
+    }
+
+    response = client.post(
+        ENDPOINT_URL,
+        headers={'Authorization': f'Bearer {token_admin}'},
+        json=new_legal_brief,
+    )
+
+    assert response.status_code == HTTPStatus.CREATED
+    content = response.json()['content']
+    assert '<strong>Texto</strong>' in content
+    assert '<script' not in content
+    assert '<img' not in content
+    assert 'onerror' not in content
+
+
+@pytest.mark.asyncio
+async def test_update_legal_brief_sanitizes_content(
+    session, client, user_admin, token_admin
+):
+    brief = LegalBrief(title='Original', content='Conteúdo inicial')
+    brief.created_by_id = user_admin.id
+    session.add(brief)
+    await session.commit()
+
+    response = client.put(
+        ENDPOINT_URL + f'/{brief.id}',
+        headers={'Authorization': f'Bearer {token_admin}'},
+        json={
+            'title': 'Atualizado',
+            'content': '<p>Novo <script>alert(1)</script></p>',
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    content = response.json()['content']
+    assert 'Novo' in content
+    assert '<script' not in content
+    assert 'onerror' not in content
+
+
 def test_create_legal_brief_value_missing(client, user_admin, token_admin):
     new_legal_brief = {
         'title': '',
@@ -194,6 +245,64 @@ async def test_update_legal_brief_creates_revision(
 
     assert revisions is not None
     assert revisions[0]['content'] == 'Conteúdo inicial'
+
+
+@pytest.mark.asyncio
+async def test_update_legal_brief_formatting_only_no_new_revision(
+    session, client, user_admin, token_admin
+):
+    brief = LegalBrief(
+        title='Original',
+        content='<p>Conteúdo inicial</p>',
+    )
+    brief.created_by_id = user_admin.id
+    session.add(brief)
+    await session.commit()
+    await session.refresh(brief)
+
+    response = client.put(
+        ENDPOINT_URL + f'/{brief.id}',
+        headers={'Authorization': f'Bearer {token_admin}'},
+        json={
+            'title': 'Original',
+            'content': '<p><strong>Conteúdo inicial</strong></p>',
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    data = response.json()
+    assert data['title'] == 'Original'
+    assert data['content'] == '<p><strong>Conteúdo inicial</strong></p>'
+    assert data['revisions'] == []
+
+
+@pytest.mark.asyncio
+async def test_update_legal_brief_title_change_creates_revision(
+    session, client, user_admin, token_admin
+):
+    brief = LegalBrief(
+        title='Original',
+        content='<p>Conteúdo inicial</p>',
+    )
+    brief.created_by_id = user_admin.id
+    session.add(brief)
+    await session.commit()
+    await session.refresh(brief)
+
+    response = client.put(
+        ENDPOINT_URL + f'/{brief.id}',
+        headers={'Authorization': f'Bearer {token_admin}'},
+        json={
+            'title': 'Novo título',
+            'content': '<p><strong>Conteúdo inicial</strong></p>',
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    data = response.json()
+    assert data['title'] == 'Novo título'
+    assert data['revisions'] is not None
+    assert data['revisions'][0]['content'] == '<p>Conteúdo inicial</p>'
 
 
 def test_update_legal_brief_not_found(session, client, token_admin):

--- a/tests/test_legal_brief.py
+++ b/tests/test_legal_brief.py
@@ -247,64 +247,6 @@ async def test_update_legal_brief_creates_revision(
     assert revisions[0]['content'] == 'Conteúdo inicial'
 
 
-@pytest.mark.asyncio
-async def test_update_legal_brief_formatting_only_no_new_revision(
-    session, client, user_admin, token_admin
-):
-    brief = LegalBrief(
-        title='Original',
-        content='<p>Conteúdo inicial</p>',
-    )
-    brief.created_by_id = user_admin.id
-    session.add(brief)
-    await session.commit()
-    await session.refresh(brief)
-
-    response = client.put(
-        ENDPOINT_URL + f'/{brief.id}',
-        headers={'Authorization': f'Bearer {token_admin}'},
-        json={
-            'title': 'Original',
-            'content': '<p><strong>Conteúdo inicial</strong></p>',
-        },
-    )
-
-    assert response.status_code == HTTPStatus.OK
-    data = response.json()
-    assert data['title'] == 'Original'
-    assert data['content'] == '<p><strong>Conteúdo inicial</strong></p>'
-    assert data['revisions'] == []
-
-
-@pytest.mark.asyncio
-async def test_update_legal_brief_title_change_creates_revision(
-    session, client, user_admin, token_admin
-):
-    brief = LegalBrief(
-        title='Original',
-        content='<p>Conteúdo inicial</p>',
-    )
-    brief.created_by_id = user_admin.id
-    session.add(brief)
-    await session.commit()
-    await session.refresh(brief)
-
-    response = client.put(
-        ENDPOINT_URL + f'/{brief.id}',
-        headers={'Authorization': f'Bearer {token_admin}'},
-        json={
-            'title': 'Novo título',
-            'content': '<p><strong>Conteúdo inicial</strong></p>',
-        },
-    )
-
-    assert response.status_code == HTTPStatus.OK
-    data = response.json()
-    assert data['title'] == 'Novo título'
-    assert data['revisions'] is not None
-    assert data['revisions'][0]['content'] == '<p>Conteúdo inicial</p>'
-
-
 def test_update_legal_brief_not_found(session, client, token_admin):
     response = client.put(
         ENDPOINT_URL + '/9999',

--- a/tests/test_notice.py
+++ b/tests/test_notice.py
@@ -43,6 +43,31 @@ def test_create_notice_without_permission(client, user, token):
     assert response.status_code == HTTPStatus.FORBIDDEN
 
 
+def test_create_notice_sanitizes_content(client, user_admin, token_admin):
+    new_notice = {
+        'title': 'Aviso com HTML',
+        'content': (
+            '<p><em>Texto</em>'
+            '<script>alert("xss")</script>'
+            '<img src="x" onerror="alert(1)">'
+            '</p>'
+        ),
+    }
+
+    response = client.post(
+        ENDPOINT_URL,
+        headers={'Authorization': f'Bearer {token_admin}'},
+        json=new_notice,
+    )
+
+    assert response.status_code == HTTPStatus.CREATED
+    content = response.json()['content']
+    assert '<em>Texto</em>' in content
+    assert '<script' not in content
+    assert '<img' not in content
+    assert 'onerror' not in content
+
+
 def test_create_notice_value_missing(client, user_admin, token_admin):
     new_notice = {'title': '', 'content': 'Conteúdo do aviso teste'}
 


### PR DESCRIPTION
Sanitiza conteúdo HTML rico (ementas e avisos) no backend com `bleach`, permitindo apenas as tags do editor TipTap e `text-align` via CSSSanitizer.

- `internum/utils/sanitize.py`: `sanitize_rich_text()`
- Validators em `legal_briefs/schemas.py` e `notices/schemas.py`
- Deps: `bleach` + `tinycss2`
- Testes de sanitização (script/img/onerror removidos)