### PR TITLE
feat(legal-briefs): não criar revisão para alterações apenas de formatação

### DIFF
--- a/internum/modules/legal_briefs/routers.py
+++ b/internum/modules/legal_briefs/routers.py
@@ -19,6 +19,7 @@ from internum.modules.legal_briefs.schemas import (
     PageMeta,
     PaginatedLegalBriefList,
 )
+from internum.utils.sanitize import plain_text
 
 router = APIRouter(prefix='/legal-briefs', tags=['Legal Briefs'])
 Session = Annotated[AsyncSession, Depends(get_session)]
@@ -199,15 +200,21 @@ async def update_legal_brief(
         )
 
     try:
-        revision = LegalBriefRevision(
-            brief_id=current_brief.id,
-            title=current_brief.title,
-            content=current_brief.content,
+        content_changed = plain_text(data.content) != plain_text(
+            current_brief.content
         )
-        revision.created_by_id = current_brief.created_by_id
-        revision.created_by = current_brief.created_by
-        revision.mark_updated(current_brief.id)
-        session.add(revision)
+        create_revision = data.title != current_brief.title or content_changed
+
+        if create_revision:
+            revision = LegalBriefRevision(
+                brief_id=current_brief.id,
+                title=current_brief.title,
+                content=current_brief.content,
+            )
+            revision.created_by_id = current_brief.created_by_id
+            revision.created_by = current_brief.created_by
+            revision.mark_updated(current_brief.id)
+            session.add(revision)
 
         current_brief.title = data.title or current_brief.title
         current_brief.content = data.content or current_brief.content

--- a/internum/utils/sanitize.py
+++ b/internum/utils/sanitize.py
@@ -1,3 +1,6 @@
+import re
+from html import unescape
+
 import bleach
 from bleach.css_sanitizer import CSSSanitizer
 
@@ -57,3 +60,17 @@ def sanitize_rich_text(value: str) -> str:
         css_sanitizer=RICH_TEXT_CSS,
         strip=True,
     ).strip()
+
+
+def plain_text(value: str) -> str:
+    """Extrai o texto puro de um HTML rico, ignorando marcação de formatação.
+
+    Remove tags, decodifica entidades e normaliza espaços em branco, permitindo
+    comparar o conteúdo semântico de dois HTMLs independentemente da
+    formatação.
+    """
+    if not isinstance(value, str):
+        return ''
+    text = re.sub(r'<[^>]*>', '', value)
+    text = unescape(text)
+    return re.sub(r'\s+', ' ', text).strip()

--- a/tests/test_legal_brief.py
+++ b/tests/test_legal_brief.py
@@ -247,6 +247,64 @@ async def test_update_legal_brief_creates_revision(
     assert revisions[0]['content'] == 'Conteúdo inicial'
 
 
+@pytest.mark.asyncio
+async def test_update_legal_brief_formatting_only_no_new_revision(
+    session, client, user_admin, token_admin
+):
+    brief = LegalBrief(
+        title='Original',
+        content='<p>Conteúdo inicial</p>',
+    )
+    brief.created_by_id = user_admin.id
+    session.add(brief)
+    await session.commit()
+    await session.refresh(brief)
+
+    response = client.put(
+        ENDPOINT_URL + f'/{brief.id}',
+        headers={'Authorization': f'Bearer {token_admin}'},
+        json={
+            'title': 'Original',
+            'content': '<p><strong>Conteúdo inicial</strong></p>',
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    data = response.json()
+    assert data['title'] == 'Original'
+    assert data['content'] == '<p><strong>Conteúdo inicial</strong></p>'
+    assert data['revisions'] == []
+
+
+@pytest.mark.asyncio
+async def test_update_legal_brief_title_change_creates_revision(
+    session, client, user_admin, token_admin
+):
+    brief = LegalBrief(
+        title='Original',
+        content='<p>Conteúdo inicial</p>',
+    )
+    brief.created_by_id = user_admin.id
+    session.add(brief)
+    await session.commit()
+    await session.refresh(brief)
+
+    response = client.put(
+        ENDPOINT_URL + f'/{brief.id}',
+        headers={'Authorization': f'Bearer {token_admin}'},
+        json={
+            'title': 'Novo título',
+            'content': '<p><strong>Conteúdo inicial</strong></p>',
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    data = response.json()
+    assert data['title'] == 'Novo título'
+    assert data['revisions'] is not None
+    assert data['revisions'][0]['content'] == '<p>Conteúdo inicial</p>'
+
+
 def test_update_legal_brief_not_found(session, client, token_admin):
     response = client.put(
         ENDPOINT_URL + '/9999',


### PR DESCRIPTION
Ao editar uma ementa, agora só é criada `LegalBriefRevision` quando o **texto** (ignorando marcação HTML) ou o **título** mudam. Alterações puramente de formatação (mesmo conteúdo, tags/estilo diferentes — ex.: editor TipTap) atualizam diretamente a `LegalBrief`.

- `internum/utils/sanitize.py`: helper `plain_text()` (remove tags, decodifica entidades, normaliza espaços)
- `internum/modules/legal_briefs/routers.py`: `update_legal_brief` só cria revisão se `title` ou `plain_text(content)` mudarem
- Testes: formatação pura não gera revisão; mudança de título gera revisão