### PR TITLE
chore: publish to GHCR and bump version to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Todas as mudanças relevantes desta imagem serão documentadas neste arquivo.
 O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/)
 e o versionamento segue o padrão [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [1.2.0] - 2026-08-20
+
+### Added
+
+- Sanitização do conteúdo rico (HTML do editor TipTap) em ementas e avisos com
+  `bleach`: permitidas apenas as tags do editor, atributos `href`/`title`/etc.
+  em links e `text-align` via `CSSSanitizer` (deps `bleach` + `tinycss2`).
+- `update_legal_brief` agora só cria `LegalBriefRevision` quando o **texto**
+  (ignorando marcação HTML) ou o **título** mudam. Alterações apenas de
+  formatação (mesmo conteúdo) atualizam a `LegalBrief` diretamente, sem nova
+  revisão (helper `plain_text()`).
+
 ## [1.1.1] - 2026-08-13
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "internum"
-version = "1.1.1"
+version = "1.2.0"
 description = ""
 authors = [{ name = "Pedro Nora", email = "pedro@nora.vc" }]
 readme = "README.md"


### PR DESCRIPTION
Release **1.2.0** do internum-api.

- Sanitização de conteúdo rico (bleach) em ementas e avisos
- Revisão de ementa apenas quando o texto/título muda (formatação pura atualiza a ementa)
- CHANGELOG atualizado

Após merge, a tag v1.2.0 publicará a imagem no GHCR.