### PR TITLE
docs: update README and AGENTS to reflect content sanitization and revision rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,8 @@ VerifyAdmin          # role == 'admin'
 ### Legal Briefs (`internum/modules/legal_briefs/`)
 - **Models**: `LegalBrief` with revisions (versioning)
 - **Audit**: Full `AuditMixin` tracking
+- **Sanitização**: Conteúdo rico é sanitizado com `bleach` via `internum/utils/sanitize.py` (`sanitize_rich_text`); compare conteúdo por texto puro (`plain_text`) para decidir se houve mudança real
+- **Revisão**: Nova `LegalBriefRevision` é criada **apenas** quando o título ou o texto puro do conteúdo mudam — formatação pura (sem alteração de texto) não gera revisão
 
 ### Notices (`internum/modules/notices/`)
 - **Model**: `Notice` with read tracking per user
@@ -239,5 +241,6 @@ poetry run alembic upgrade head
 | `internum/core/permissions.py` | Permission dependencies |
 | `internum/core/models/registry.py` | SQLAlchemy registry |
 | `internum/core/models/mixins.py` | AuditMixin |
+| `internum/utils/sanitize.py` | Sanitização de conteúdo rico (`sanitize_rich_text`) + `plain_text` |
 | `pyproject.toml` | Dependencies, Ruff, pytest, tasks |
 | `.env.development` | Local environment variables |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Construída com **FastAPI**, **SQLAlchemy**, **PostgreSQL** e **Alembic**, a apl
 - **PostgreSQL**
 - **Alembic**
 - **Pydantic**
+- **bleach** (sanitização de conteúdo rico)
 - **holidays**
 - **Poetry**
 - **Docker & Docker Compose**
@@ -108,7 +109,8 @@ Construída com **FastAPI**, **SQLAlchemy**, **PostgreSQL** e **Alembic**, a apl
 │   ├── scripts
 │   │   └── seed_admin.py
 │   └── utils
-│       └── datetime.py
+│       ├── datetime.py
+│       └── sanitize.py
 ├── migrations
 │   ├── env.py
 │   ├── README
@@ -234,21 +236,21 @@ task dockerBuild
 
 A imagem de produção fica em **GHCR**: `ghcr.io/pedronora/internum-api`.
 
-- Tag de release: `:1.0.0` (imutável, usa-se em produção)
+- Tag de release: `:1.2.0` (imutável, usa-se em produção)
 - Tag de desenvolvimento: `:latest` e `:sha-<commit>`
 - O CI (`docker-publish.yaml`) publica `latest` nos merges para `main` e `X.Y.Z` quando uma tag `vX.Y.Z` é criada.
 
 No TrueNAS:
 
-1. Use a imagem `ghcr.io/pedronora/internum-api:1.0.0` (pull direto, sem `docker save/load`).
+1. Use a imagem `ghcr.io/pedronora/internum-api:1.2.0` (pull direto, sem `docker save/load`).
 2. Crie o app usando essa imagem.
 3. Configure as variáveis de ambiente de produção no painel (ex.: `POSTGRES_*`, `SECRET_KEY`, `MAILTRAP_TOKEN`) ou via `env_file`.
 
 ## 🏷️ Criar uma release
 
 ```bash
-git tag v1.0.0
-git push origin v1.0.0
+git tag v1.2.0
+git push origin v1.2.0
 ```
 
 O CI publica a imagem com o rótulo da versão no GHCR.
@@ -273,7 +275,7 @@ Observações:
 
 - library – biblioteca técnica interna (livros, empréstimos, categorias)
 
-- legal_briefs – Ementas de entendimentos jurídicos consolidados internamente
+- legal_briefs – Ementas de entendimentos jurídicos consolidados internamente (conteúdo rico sanitizado com `bleach`; revisão criada apenas quando título ou conteúdo mudam — formatação pura não gera revisão)
 
 - vacation – gestão de férias (períodos aquisitivos, concessões, solicitações e alertas)
 


### PR DESCRIPTION
## Resumo

Atualização de documentação para refletir o trabalho recente — sem alteração de release (sem bump de versão/tag).

## Alterações

- **README.md**: `bleach` nas tecnologias; `internum/utils/sanitize.py` na estrutura; regra de revisão por formatação documentada no módulo `legal_briefs`; tags GHCR `:1.0.0` → `:1.2.0`.
- **AGENTS.md**: módulo `legal_briefs` com sanitização (`sanitize_rich_text`/`plain_text`) e regra de revisão (formatação pura não gera revisão); `sanitize.py` no Key Files Reference.